### PR TITLE
Updated the chrispl-run command ex. for FS plugins

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -262,9 +262,10 @@ Run an FS plugin, ``pl-mri10yr06mo01da_normal``
                     "port":         "8000",
                     "address":      "%HOSTIP",
                     "user":         "chris",
-                    "password":     "chris1234"}'
+                    "password":     "chris1234"}'       \
+                --args="dummyData"
 
-This plugin does not require any specific CLI args when run in the default state. Once posted to CUBE, a string is returned to the shell:
+Although this is an FS plugin, it requires the --args flag with some dummy string to run. Once posted to CUBE, a string is returned to the shell:
 
 .. code-block:: console
 
@@ -296,7 +297,7 @@ or with some formatting:
 
     ROOTNODE=$(
         chrispl-run --plugin name=pl-mri10yr06mo01da_normal     \
-                    --onCUBE="$CUBE"                            |
+                    --onCUBE="$CUBE" --args="dummyData"         |
                          awk '{print $3}'
     )
 


### PR DESCRIPTION
Updated the chrispl-run command ex. for FS plugins

An FS plugin throws an error "Plugin run failed" when run without the --args flag
The value for the --args flag can be arbitrary